### PR TITLE
Fixing run_sample parameter for job_create

### DIFF
--- a/neverbounce_sdk/bulk.py
+++ b/neverbounce_sdk/bulk.py
@@ -249,7 +249,7 @@ class JobRunnerMixin(object):
         data = dict(input=input,
                     auto_parse=int(auto_parse),
                     auto_start=int(auto_start),
-                    as_sample=int(as_sample))
+                    run_sample=int(as_sample))
 
         data['input_location'] = 'remote_url' if from_url else 'supplied'
         if filename is not None:

--- a/tests/test_bulk_api.py
+++ b/tests/test_bulk_api.py
@@ -100,7 +100,7 @@ def test_create(client):
 
     raw_args = dict(input=['test@example.com'],
                     input_location='supplied',
-                    auto_parse=0, auto_start=0, as_sample=0)
+                    auto_parse=0, auto_start=0, run_sample=0)
 
     client.jobs_create(['test@example.com'])
     called_with = json.loads(responses.calls[0].request.body.decode('UTF-8'))


### PR DESCRIPTION
The API expects `run_sample` instead of `as_sample`. Leaving the argument for this method untouched and just changing the parameter's name in the JSON.